### PR TITLE
NPO API Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@
 
 Lookup one or more media objects in POMS. Designed to be integrated in your CMS.
 
+## CMS Integration
+
+An example integration is available at: https://codepen.io/leonderijke/pen/pRxPGb
+
+It boils down to:
+
+1. Add an event listener for the `message` event (see [postMessage](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage#The_dispatched_event)).
+2. After a user action (e.g. user clicks a button), open the POMS Lookup in a popup window.
+3. After the user selects one or more items and clicks the "Choose selection" button, a message will be posted to your window. The mids will be available as an array on the `data` property of the message event.
+
+In the `message` event handler you should check if the origin of the message is the POMS Lookup page, to prevent security issues. You can also close the popup window there, if desired.
+
 ## Development
 
 Assuming you have [NVM](https://github.com/creationix/nvm) and [Yarn](https://yarnpkg.com/lang/en/) installed:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,20 @@ Assuming you have [NVM](https://github.com/creationix/nvm) and [Yarn](https://ya
 1. Clone the repository.
 2. Run `nvm use` to switch to the right Node version.
 3. Run `yarn install` to install the dependencies.
+4. Set the right environment variables (see below).
 4. Run `yarn start` to start the local development build.
+
+In order to use the NPO API, you need to set a number of environment variables. The easiest way is to create a `.env` file in the project root, containing:
+
+```bash
+HOST=<your-hostname>
+REACT_APP_NPO_API_KEY=<your-key>
+REACT_APP_NPO_API_SECRET=<your-secret>
+```
+
+The `HOST` is used as the origin in NPO API requests, so be sure to set it to an allowed host. Don't forget to add this host to your `/etc/hosts` file.
+
+The `REACT_APP_NPO_API_KEY` and `REACT_APP_NPO_API_SECRET` should be set to the credentials to use to sign the NPO API request.
 
 ## User Guide
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,21 @@ It boils down to:
 
 In the `message` event handler you should check if the origin of the message is the POMS Lookup page, to prevent security issues. You can also close the popup window there, if desired.
 
+### Filtering
+
+It is possible to add some filters to the POMS Lookup URL, in order to set these as default filters in POMS Lookup. For example, in some situations you want to lookup seasons, in other situations you want to lookup broadcasts and clips.
+
+Currently supported filters:
+
+- `types`: Types to match
+- `broadcasters`: Broadcasters to match
+
+For example: `CLIP`s and `BROADCAST`s from the `EO`:
+
+```
+https://pomslookup.eo.nl/?types=CLIP&types=BROADCAST&broadcasters=EO
+```
+
 ## Development
 
 Assuming you have [NVM](https://github.com/creationix/nvm) and [Yarn](https://yarnpkg.com/lang/en/) installed:

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "standard": "^8.6.0"
   },
   "dependencies": {
+    "axios": "^0.15.3",
     "classnames": "^2.2.5",
+    "jssha": "^2.2.0",
     "react": "^15.4.2",
     "react-addons-shallow-compare": "^15.4.2",
     "react-dom": "^15.4.2",

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1,0 +1,41 @@
+import axios from 'axios'
+
+import npoApiInterceptor from './npoApiInterceptor'
+import transformItem from './transformItem'
+
+// Configure Axios to use the NPO API Request Interceptor
+axios.interceptors.request.use(npoApiInterceptor({
+  key: process.env.REACT_APP_NPO_API_KEY,
+  secret: process.env.REACT_APP_NPO_API_SECRET
+}))
+
+const API_URL = 'https://rs.poms.omroep.nl/v1/api'
+
+const api = {
+  media: ({ text }) =>
+    axios({
+      url: '/media',
+      baseURL: API_URL,
+      method: 'post',
+      params: {
+        properties: 'none'
+      },
+      data: {
+        searches: {
+          text: text
+        },
+        sort: {
+          sortDate: 'DESC'
+        }
+      }
+    })
+    .then(res => {
+      if (!res.data || !res.data.items) {
+        throw new Error(`No items found`)
+      }
+
+      return res.data.items.map((item) => transformItem(item.result))
+    })
+}
+
+export default api

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -18,7 +18,8 @@ const api = {
       baseURL: API_URL,
       method: 'post',
       params: {
-        properties: 'none'
+        properties: 'none',
+        max: 240
       },
       data: {
         searches: {

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -11,8 +11,44 @@ axios.interceptors.request.use(npoApiInterceptor({
 
 const API_URL = 'https://rs.poms.omroep.nl/v1/api'
 
+/**
+ * Creats a matcher for multiple values
+ *
+ * @param   {Array}  values
+ * @returns {Object}
+ */
+const createMultipleValueMatcher = (values) => ({
+  match: 'MUST',
+  value: values.map(v => ({
+    value: v,
+    match: 'SHOULD'
+  }))
+})
+
+/**
+ * Formats the Search Query to be passed to the NPO API
+ *
+ * @param   {Object} query
+ * @returns {Object}
+ */
+const formatSearchQuery = ({ text, types = [], broadcasters = [] }) => {
+  let searches = {
+    text: text
+  }
+
+  if (types.length) {
+    searches.types = createMultipleValueMatcher(types)
+  }
+
+  if (broadcasters.length) {
+    searches.broadcasters = createMultipleValueMatcher(broadcasters)
+  }
+
+  return searches
+}
+
 const api = {
-  media: ({ text }) =>
+  media: ({ text, types = [], broadcasters = [] }) =>
     axios({
       url: '/media',
       baseURL: API_URL,
@@ -22,9 +58,7 @@ const api = {
         max: 240
       },
       data: {
-        searches: {
-          text: text
-        },
+        searches: formatSearchQuery({ text, types, broadcasters }),
         sort: {
           sortDate: 'DESC'
         }

--- a/src/api/npoApiInterceptor.js
+++ b/src/api/npoApiInterceptor.js
@@ -1,0 +1,178 @@
+import JsSHA from 'jssha'
+
+// TODO: Move this to a separate NPM Package
+
+/**
+ * URL's in use with the NPO API
+ *
+ * @type {Array}
+ */
+const NPO_API_URLS = [
+  // Test
+  'https://rs-test.poms.omroep.nl/v1/api',
+  // Production
+  'https://rs.poms.omroep.nl/v1/api'
+]
+
+/**
+ * Checks whether we're intercepting a request to the POMS API
+ *
+ * @param   {String}  url Complete URL
+ * @returns {boolean}
+ */
+const validateUrl = url => NPO_API_URLS.some(apiUrl => url.indexOf(apiUrl) === 0)
+
+/**
+ * Returns a comma-separated `key:value` string representation of an object
+ *
+ * @param   {Object} obj
+ * @returns {String}
+ */
+const getObjectString = obj =>
+  Object.keys(obj)
+    .map(key => key + ':' + obj[key])
+    .join()
+
+/**
+ * Returns a ordered comma-separated `key:value` string representation of an object
+ *
+ * @param   {Object} obj
+ * @returns {String}
+ */
+const getSortedObjectString = obj =>
+  Object.keys(obj)
+    .sort()
+    .map(key => key + ':' + obj[key])
+    .join()
+
+/**
+ * Encrypts a message with a secret, using SHA256 implementation.
+ *
+ * Returns the base64-encoded HMAC.
+ *
+ * @param   {String} secret
+ * @param   {String} message
+ * @returns {String}
+ */
+const encrypt = (secret, message) => {
+  const sha = new JsSHA('SHA-256', 'TEXT')
+
+  sha.setHMACKey(secret, 'TEXT')
+  sha.update(message)
+
+  return sha.getHMAC('B64')
+}
+
+/**
+ * Parses a URL and returns the pathname
+ *
+ * @param   {String} url
+ * @returns {String}
+ */
+const getPathnameFromUrl = url => {
+  const parser = document.createElement('a')
+  parser.href = url
+
+  return parser.pathname
+}
+
+/**
+ * Formats a given date to the necessary format
+ *
+ * @param   {Date} date
+ * @returns {String}
+ */
+const formatDate = date => date.toUTCString()
+
+/**
+ * Factory function for creating NPO API Interceptors
+ *
+ * @param   {Object}   config
+ * @returns {Function}
+ */
+const createNpoApiInterceptor = ({ key, secret, origin = '' }) => {
+  if (!key || !secret) {
+    throw new Error('NPO API Interceptor: Key and secret are mandatory')
+  }
+
+  /**
+   * Calculates the signed message part of the Authorization header
+   *
+   * @param   {Object} config      Config of the request
+   * @param   {Date}   requestDate Date of the request
+   * @returns {Object}
+   */
+  function signRequest (config, requestDate) {
+    let message = {
+      'origin': getOrigin(),
+      'x-npo-date': formatDate(requestDate),
+      'uri': getPathnameFromUrl(config.url)
+    }
+
+    if (config.params && Object.keys(config.params).length) {
+      message.uri += ',' + getSortedObjectString(config.params)
+    }
+
+    return encrypt(secret, getObjectString(message))
+  }
+
+  /**
+   * Determines the Authorization header value
+   *
+   * @param   {Object} request The request
+   * @param   {Date}   requestDate Date of the request
+   * @returns {String}
+   */
+  function getAuthorizationHeader (request, requestDate) {
+    return `NPO ${key}:${signRequest(request, requestDate)}`
+  }
+
+  /**
+   * Determines the Origin header value
+   *
+   * @returns {String}
+   */
+  function getOrigin () {
+    if (typeof window === 'undefined') {
+      return origin
+    }
+
+    return window.location.origin
+  }
+
+  /**
+   * Determines the necessary NPO API headers
+   *
+   * @param   {Object} config Axios Request object
+   * @returns {Object}
+   */
+  function getNpoApiHeaders (config) {
+    const requestDate = new Date()
+
+    let headers = {
+      'X-NPO-Date': formatDate(requestDate),
+      'Authorization': getAuthorizationHeader(config, requestDate),
+      'Content-Type': 'application/json',
+      'Accept': 'application/json'
+    }
+
+    if (typeof window === 'undefined') {
+      headers.Origin = origin
+    }
+
+    return headers
+  }
+
+  return function (config) {
+    if (!validateUrl(config.url)) {
+      return config
+    }
+
+    return Promise.resolve(config)
+      .then(config => Object.assign({}, config, {
+        headers: getNpoApiHeaders(config)
+      }))
+  }
+}
+
+export default createNpoApiInterceptor

--- a/src/api/transformItem.js
+++ b/src/api/transformItem.js
@@ -2,7 +2,7 @@ const transformItem = (item) => {
   return {
     ...item,
     title: item.titles[0].value,
-    date: item.sortDate
+    date: new Date(item.sortDate).toLocaleDateString()
   }
 }
 

--- a/src/api/transformItem.js
+++ b/src/api/transformItem.js
@@ -1,0 +1,9 @@
+const transformItem = (item) => {
+  return {
+    ...item,
+    title: item.titles[0].value,
+    date: item.sortDate
+  }
+}
+
+export default transformItem

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -4,15 +4,9 @@ import Button from '../components/Button'
 import SearchResults from '../components/SearchResults'
 import ErrorMessage from '../components/ErrorMessage'
 import LoadingIndicator from '../components/LoadingIndicator'
+import api from '../api'
 
 import './App.css'
-
-const MOCK_RESULTS = [
-  { mid: 'POMS_EO_7337515', title: 'Vlog: prinses Beatrix bezoekt Madurodam', date: 1486577234482, type: 'CLIP' },
-  { mid: 'POMS_EO_7167107', title: 'Vlog: Achter de schermen bij de opening van Thialf', date: 1485589331114, type: 'CLIP' },
-  { mid: 'POMS_EO_7001692', title: 'Vlog Joël Voordewind uit Israël', date: 1484749688641, type: 'CLIP' },
-  { mid: 'POMS_EO_5284895', title: 'Zapp Your Planet Vlog - Rondleiding kamp', date: 1475146440000, type: 'CLIP' }
-]
 
 class App extends Component {
   state = {
@@ -23,16 +17,28 @@ class App extends Component {
   }
 
   onSearchFormSubmit = ({ text }) => {
+    if (this.state.isLoading) {
+      return
+    }
+
     this.setState({
       isLoading: true
     })
 
-    window.setTimeout(() => {
-      this.setState({
-        isLoading: false,
-        results: MOCK_RESULTS
+    api.media({ text })
+      .then((results) => {
+        this.setState({
+          isLoading: false,
+          results: results
+        })
       })
-    }, 3000)
+      .catch((error) => {
+        console.error(error)
+        this.setState({
+          isLoading: false,
+          error: error
+        })
+      })
   }
 
   onSearchResultClick = ({ mid }) => {

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -102,7 +102,7 @@ class App extends Component {
           <p>
             {selection.length ? <Button onClick={this.onChooseSelection}>Kies {selection.length} {selection.length === 1 ? 'geselecteerd item' : 'geselecteerde items'}</Button> : ''}
           </p>
-          <p>POMS Lookup</p>
+          <p>POMS Lookup | <a href='https://github.com/evangelischeomroep/poms-lookup' target='_blank'>GitHub</a></p>
         </footer>
       </div>
     )

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -8,6 +8,18 @@ import api from '../api'
 
 import './App.css'
 
+const getFiltersFromUrl = () => {
+  const searchParams = new window.URLSearchParams(window.location.search)
+
+  return ['types', 'broadcasters'].reduce((filters, current) => {
+    if (searchParams.getAll(current)) {
+      filters[current] = searchParams.getAll(current)
+    }
+
+    return filters
+  }, {})
+}
+
 class App extends Component {
   state = {
     results: [],
@@ -25,7 +37,7 @@ class App extends Component {
       isLoading: true
     })
 
-    api.media({ text })
+    api.media({ text, ...getFiltersFromUrl() })
       .then((results) => {
         this.setState({
           isLoading: false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -221,6 +221,12 @@ aws4@^1.2.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
 
+axios@^0.15.3:
+  version "0.15.3"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.15.3.tgz#2c9d638b2e191a08ea1d6cc988eadd6ba5bdc053"
+  dependencies:
+    follow-redirects "1.0.0"
+
 babel-code-frame@^6.11.0, babel-code-frame@^6.16.0, babel-code-frame@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.22.0.tgz#027620bee567a88c32561574e7fd0801d33118e4"
@@ -2274,6 +2280,12 @@ flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
 
+follow-redirects@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.0.0.tgz#8e34298cbd2e176f254effec75a1c78cc849fd37"
+  dependencies:
+    debug "^2.2.0"
+
 for-in@^0.1.5:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-0.1.6.tgz#c9f96e89bfad18a545af5ec3ed352a1d9e5b4dc8"
@@ -3250,6 +3262,10 @@ jsprim@^1.2.2:
     extsprintf "1.0.2"
     json-schema "0.2.3"
     verror "1.3.6"
+
+jssha@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/jssha/-/jssha-2.2.0.tgz#87dcf60821dc3bec593f3855bbebccd276aacc1c"
 
 jsx-ast-utils@^1.0.0, jsx-ast-utils@^1.3.1, jsx-ast-utils@^1.3.3:
   version "1.4.0"


### PR DESCRIPTION
Adds possibility to filter on `types` and `broadcasters`, by passing these in the POMS Lookup URL you open. For example:

```
https://pomslookup.eo.nl/?types=CLIP&types=BROADCAST&broadcasters=EO
```

Replaces the mock data with a real API call and the real results.