### PR TITLE
Add support for the Profile parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,16 @@ For example: `CLIP`s and `BROADCAST`s from the `EO`:
 https://pomslookup.eo.nl/?types=CLIP&types=BROADCAST&broadcasters=EO
 ```
 
+### Profile
+
+It is possible to use a profile by adding the `profile` parameter to the POMS Lookup URL. Please note that the existence of the profile is not validated. For example, to specify the `eo` profile, use this URL to POMS Lookup:
+
+```
+https://pomslookup.eo.nl/?profile=eo
+```
+
+You can use both a profile and filtering, if desired.
+
 ## Development
 
 Assuming you have [NVM](https://github.com/creationix/nvm) and [Yarn](https://yarnpkg.com/lang/en/) installed:

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -2,6 +2,7 @@ import axios from 'axios'
 
 import npoApiInterceptor from './npoApiInterceptor'
 import transformItem from './transformItem'
+import { getProfileFromUrl } from '../utils/urlHelpers'
 
 // Configure Axios to use the NPO API Request Interceptor
 axios.interceptors.request.use(npoApiInterceptor({
@@ -48,15 +49,23 @@ const formatSearchQuery = ({ text, types = [], broadcasters = [] }) => {
 }
 
 const api = {
-  media: ({ text, types = [], broadcasters = [] }) =>
-    axios({
+  media: ({ text, types = [], broadcasters = [] }) => {
+    const profile = getProfileFromUrl()
+
+    const params = {
+      properties: 'none',
+      max: 240
+    }
+
+    if (profile) {
+      params.profile = profile
+    }
+
+    return axios({
       url: '/media',
       baseURL: API_URL,
       method: 'post',
-      params: {
-        properties: 'none',
-        max: 240
-      },
+      params: params,
       data: {
         searches: formatSearchQuery({ text, types, broadcasters }),
         sort: {
@@ -71,6 +80,7 @@ const api = {
 
       return res.data.items.map((item) => transformItem(item.result))
     })
+  }
 }
 
 export default api

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -5,7 +5,7 @@ import SearchResults from '../components/SearchResults'
 import ErrorMessage from '../components/ErrorMessage'
 import LoadingIndicator from '../components/LoadingIndicator'
 import api from '../api'
-import getFiltersFromUrl from '../utils/getFiltersFromUrl'
+import { getFiltersFromUrl } from '../utils/urlHelpers'
 
 import './App.css'
 

--- a/src/containers/App.test.js
+++ b/src/containers/App.test.js
@@ -5,7 +5,7 @@ import { mount, shallow } from 'enzyme'
 import App from './App'
 import api from '../api'
 
-jest.mock('../utils/getFiltersFromUrl')
+jest.mock('../utils/urlHelpers')
 jest.mock('../api')
 
 it('renders without crashing', () => {

--- a/src/utils/urlHelpers.js
+++ b/src/utils/urlHelpers.js
@@ -13,3 +13,9 @@ export const getFiltersFromUrl = () => {
     return filters
   }, {})
 }
+
+export const getProfileFromUrl = () => {
+  const searchParams = new URLSearchParams(window.location.search)
+
+  return searchParams.get('profile')
+}

--- a/src/utils/urlHelpers.js
+++ b/src/utils/urlHelpers.js
@@ -2,7 +2,7 @@ import URLSearchParamsPolyfill from 'url-search-params'
 
 const URLSearchParams = window.URLSearchParams || URLSearchParamsPolyfill
 
-const getFiltersFromUrl = () => {
+export const getFiltersFromUrl = () => {
   const searchParams = new URLSearchParams(window.location.search)
 
   return ['types', 'broadcasters'].reduce((filters, current) => {
@@ -13,5 +13,3 @@ const getFiltersFromUrl = () => {
     return filters
   }, {})
 }
-
-export default getFiltersFromUrl


### PR DESCRIPTION
Adds support for using the `profile` parameter in NPO API requests.

By adding a `profile` parameter to the POMS Lookup URL the specified profile will be used in searching the NPO API. For example: `https://pomslookup.eo.nl/?profile=eo-playable` will use the `eo-playable` profile, returning only playable media items from EO.

Note that the existence of the profile is not validated. If a non-existing profile value is passed, the NPO API will return a 404 on the request.