### PR TITLE
Add support for limiting the selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ https://pomslookup.eo.nl/?profile=eo
 
 You can use both a profile and filtering, if desired.
 
+### Limit
+
+It is possible to limit the number of items that can be selected. For example, if you only expect one item from the POMS Lookup or if you expect a maximum of five items from the POMS Lookup. You can specify the limit by adding the `limit` parameter to the POMS Lookup URL:
+
+```
+https://pomslookup.eo.nl/?limit=1
+```
+
 ## Development
 
 Assuming you have [NVM](https://github.com/creationix/nvm) and [Yarn](https://yarnpkg.com/lang/en/) installed:

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -44,13 +44,15 @@ class App extends Component {
   }
 
   onSearchResultClick = ({ mid }) => {
+    const limit = this.props.selectionLimit
+
     // Remove from selection if it is already selected
     if (this.state.selection.indexOf(mid) > -1) {
       this.setState({
         selection: this.state.selection.filter(item => item !== mid)
       })
-    // Add to selection if not already selected
-    } else {
+    // Add to selection if not already selected and selection limit is not reached yet
+    } else if (!limit || (this.state.selection.length < limit)) {
       this.setState({
         selection: [...this.state.selection, mid]
       })
@@ -61,6 +63,16 @@ class App extends Component {
     if (window.opener) {
       window.opener.postMessage({ mids: this.state.selection }, '*')
     }
+  }
+
+  renderLimitMessage = () => {
+    const limit = this.props.selectionLimit
+
+    if (limit && this.state.results.length) {
+      return <p>Je kunt maximaal {limit} {limit === 1 ? 'item' : 'items'} selecteren</p>
+    }
+
+    return null
   }
 
   renderContent = () => {
@@ -96,6 +108,7 @@ class App extends Component {
         <header className='App-header'>
           <h1>POMS Lookup</h1>
           <SearchForm disabled={isLoading} onSubmit={this.onSearchFormSubmit} />
+          {this.renderLimitMessage()}
         </header>
         <div className='App-content'>
           {this.renderContent()}

--- a/src/containers/App.test.js
+++ b/src/containers/App.test.js
@@ -12,6 +12,32 @@ it('renders without crashing', () => {
   mount(<App />)
 })
 
+describe('Limit selection', () => {
+  it('renders a limit message', () => {
+    let wrapper = shallow(<App selectionLimit={1} />)
+
+    expect.assertions(1)
+    return wrapper.instance().onSearchFormSubmit({ text: 'succeed' }).then(() => {
+      expect(wrapper.find('header > p')).toHaveLength(1)
+    })
+  })
+
+  it('limits the selection', () => {
+    let wrapper = shallow(<App selectionLimit={2} />)
+    const mids = ['POMS_EO_7337515', 'POMS_EO_7167107', 'POMS_EO_7001692', 'POMS_EO_5284895']
+
+    expect.assertions(2)
+    return wrapper.instance().onSearchFormSubmit({ text: 'succeed' }).then(() => {
+      wrapper.instance().onSearchResultClick({ mid: mids[0] })
+      wrapper.instance().onSearchResultClick({ mid: mids[1] })
+      expect(wrapper.state('selection')).toHaveLength(2)
+
+      wrapper.instance().onSearchResultClick({ mid: mids[2] })
+      expect(wrapper.state('selection')).toHaveLength(2)
+    })
+  })
+})
+
 describe('Error state', () => {
   let wrapper
 

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import './index.css'
 import 'react-virtualized/styles.css'
+import { getLimitFromUrl } from './utils/urlHelpers'
 
 const root = document.getElementById('root')
 
@@ -13,7 +14,7 @@ let render = () => {
   const App = require('./containers/App').default
 
   ReactDOM.render(
-    <App />,
+    <App selectionLimit={getLimitFromUrl()} />,
     root,
   )
 }

--- a/src/utils/urlHelpers.js
+++ b/src/utils/urlHelpers.js
@@ -14,8 +14,18 @@ export const getFiltersFromUrl = () => {
   }, {})
 }
 
-export const getProfileFromUrl = () => {
+const getPropertyFromUrl = (property) => () => {
   const searchParams = new URLSearchParams(window.location.search)
 
-  return searchParams.get('profile')
+  return searchParams.get(property)
+}
+
+export const getProfileFromUrl = getPropertyFromUrl('profile')
+
+export const getLimitFromUrl = () => {
+  const limit = getPropertyFromUrl('limit')()
+
+  if (limit) {
+    return parseInt(limit, 10)
+  }
 }


### PR DESCRIPTION
Adds the `limit` parameter for limiting the selection you expect from the POMS Lookup. When a limit is set, a message will be shown to inform the user about the maximum number of items he/she can select.

When the selection limit is reached, no further items can be selected.

Example, limit selection to one item:

```
https://pomslookup.eo.nl/?limit=1
```