### PR TITLE
Post items instead of mids

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It boils down to:
 
 1. Add an event listener for the `message` event (see [postMessage](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage#The_dispatched_event)).
 2. After a user action (e.g. user clicks a button), open the POMS Lookup in a popup window.
-3. After the user selects one or more items and clicks the "Choose selection" button, a message will be posted to your window. The mids will be available as an array on the `data` property of the message event.
+3. After the user selects one or more items and clicks the "Choose selection" button, a message will be posted to your window. The items will be available as an array on the `data` property of the message event.
 
 In the `message` event handler you should check if the origin of the message is the POMS Lookup page, to prevent security issues. You can also close the popup window there, if desired.
 

--- a/src/api/__mocks__/index.js
+++ b/src/api/__mocks__/index.js
@@ -1,10 +1,10 @@
 /* eslint-env jest */
 
-const MOCK_RESULTS = [
-  { mid: 'POMS_EO_7337515', title: 'Vlog: prinses Beatrix bezoekt Madurodam', date: 1486577234482, type: 'CLIP' },
-  { mid: 'POMS_EO_7167107', title: 'Vlog: Achter de schermen bij de opening van Thialf', date: 1485589331114, type: 'CLIP' },
-  { mid: 'POMS_EO_7001692', title: 'Vlog Joël Voordewind uit Israël', date: 1484749688641, type: 'CLIP' },
-  { mid: 'POMS_EO_5284895', title: 'Zapp Your Planet Vlog - Rondleiding kamp', date: 1475146440000, type: 'CLIP' }
+export const MOCK_RESULTS = [
+  { mid: 'POMS_EO_7337515', title: 'Vlog: prinses Beatrix bezoekt Madurodam', date: 1486577234482, type: 'CLIP', avType: 'VIDEO' },
+  { mid: 'POMS_EO_7167107', title: 'Vlog: Achter de schermen bij de opening van Thialf', date: 1485589331114, type: 'CLIP', avType: 'VIDEO' },
+  { mid: 'POMS_EO_7001692', title: 'Vlog Joël Voordewind uit Israël', date: 1484749688641, type: 'CLIP', avType: 'VIDEO' },
+  { mid: 'POMS_EO_5284895', title: 'Zapp Your Planet Vlog - Rondleiding kamp', date: 1475146440000, type: 'CLIP', avType: 'VIDEO' }
 ]
 
 const apiMock = {

--- a/src/api/transformItem.js
+++ b/src/api/transformItem.js
@@ -1,8 +1,10 @@
 const transformItem = (item) => {
   return {
-    ...item,
+    mid: item.mid,
     title: item.titles[0].value,
-    date: new Date(item.sortDate).toLocaleDateString()
+    date: new Date(item.sortDate).toLocaleDateString(),
+    type: item.type,
+    avType: item.avType
   }
 }
 

--- a/src/components/SearchResults.js
+++ b/src/components/SearchResults.js
@@ -13,12 +13,12 @@ const SearchResults = ({
   const rowClassName = ({ index }) => {
     const mid = results[index] && results[index].mid
 
-    return selection.indexOf(mid) > -1 ? 'SearchResults-row is-selected' : 'SearchResults-row'
+    return selection.find(s => s.mid === mid) ? 'SearchResults-row is-selected' : 'SearchResults-row'
   }
 
   const onRowClick = ({ rowData }) => {
-    if (rowData && rowData.mid) {
-      onSearchResultClick({ mid: rowData.mid })
+    if (rowData) {
+      onSearchResultClick(rowData)
     }
   }
 

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -46,25 +46,26 @@ class App extends Component {
       })
   }
 
-  onSearchResultClick = ({ mid }) => {
+  onSearchResultClick = (item) => {
+    const mid = item.mid
     const limit = this.props.selectionLimit
 
     // Remove from selection if it is already selected
-    if (this.state.selection.indexOf(mid) > -1) {
+    if (this.state.selection.find(s => s.mid === mid)) {
       this.setState({
-        selection: this.state.selection.filter(item => item !== mid)
+        selection: this.state.selection.filter(s => s.mid !== mid)
       })
     // Add to selection if not already selected and selection limit is not reached yet
     } else if (!limit || (this.state.selection.length < limit)) {
       this.setState({
-        selection: [...this.state.selection, mid]
+        selection: [...this.state.selection, item]
       })
     }
   }
 
   onChooseSelection = () => {
     if (window.opener) {
-      window.opener.postMessage({ mids: this.state.selection }, '*')
+      window.opener.postMessage({ items: this.state.selection }, '*')
     }
   }
 

--- a/src/containers/App.test.js
+++ b/src/containers/App.test.js
@@ -28,11 +28,11 @@ describe('Limit selection', () => {
 
     expect.assertions(2)
     return wrapper.instance().onSearchFormSubmit({ text: 'succeed' }).then(() => {
-      wrapper.instance().onSearchResultClick({ mid: items[0].mid })
-      wrapper.instance().onSearchResultClick({ mid: items[1].mid })
+      wrapper.instance().onSearchResultClick(items[0])
+      wrapper.instance().onSearchResultClick(items[1])
       expect(wrapper.state('selection')).toHaveLength(2)
 
-      wrapper.instance().onSearchResultClick({ mid: items[2].mid })
+      wrapper.instance().onSearchResultClick(items[2])
       expect(wrapper.state('selection')).toHaveLength(2)
     })
   })
@@ -126,11 +126,11 @@ describe('onSearchFormSubmit', () => {
 describe('onChooseSelection', () => {
   it('posts a message to the opener', () => {
     const wrapper = shallow(<App />)
-    const mids = MOCK_RESULTS.map(i => i.mid)
+    const selection = MOCK_RESULTS.slice(0, 2)
 
-    wrapper.setState({ selection: mids })
+    wrapper.setState({ selection: selection })
     wrapper.instance().onChooseSelection()
 
-    expect(window.opener.postMessage).toHaveBeenCalledWith({ mids: mids }, '*')
+    expect(window.opener.postMessage).toHaveBeenCalledWith({ items: selection }, '*')
   })
 })

--- a/src/containers/App.test.js
+++ b/src/containers/App.test.js
@@ -3,7 +3,7 @@
 import React from 'react'
 import { mount, shallow } from 'enzyme'
 import App from './App'
-import api from '../api'
+import api, { MOCK_RESULTS } from '../api'
 
 jest.mock('../utils/urlHelpers')
 jest.mock('../api')
@@ -24,15 +24,15 @@ describe('Limit selection', () => {
 
   it('limits the selection', () => {
     let wrapper = shallow(<App selectionLimit={2} />)
-    const mids = ['POMS_EO_7337515', 'POMS_EO_7167107', 'POMS_EO_7001692', 'POMS_EO_5284895']
+    const items = MOCK_RESULTS
 
     expect.assertions(2)
     return wrapper.instance().onSearchFormSubmit({ text: 'succeed' }).then(() => {
-      wrapper.instance().onSearchResultClick({ mid: mids[0] })
-      wrapper.instance().onSearchResultClick({ mid: mids[1] })
+      wrapper.instance().onSearchResultClick({ mid: items[0].mid })
+      wrapper.instance().onSearchResultClick({ mid: items[1].mid })
       expect(wrapper.state('selection')).toHaveLength(2)
 
-      wrapper.instance().onSearchResultClick({ mid: mids[2] })
+      wrapper.instance().onSearchResultClick({ mid: items[2].mid })
       expect(wrapper.state('selection')).toHaveLength(2)
     })
   })
@@ -126,7 +126,7 @@ describe('onSearchFormSubmit', () => {
 describe('onChooseSelection', () => {
   it('posts a message to the opener', () => {
     const wrapper = shallow(<App />)
-    const mids = ['POMS_EO_7337515', 'POMS_EO_7167107', 'POMS_EO_7001692', 'POMS_EO_5284895']
+    const mids = MOCK_RESULTS.map(i => i.mid)
 
     wrapper.setState({ selection: mids })
     wrapper.instance().onChooseSelection()


### PR DESCRIPTION
Breaking change! This will post the selected items to the opener, instead of just the MIDs.

If you expect MIDs, you need to change your implementation to map over the items to extract the MIDs:

```js
// somewhere in your `message` event listener
var mids = event.data.items.map(function(item) { return item.mid; });
```