### PR TITLE
Perform initial search after mounting

### DIFF
--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -18,6 +18,10 @@ class App extends Component {
     error: undefined
   }
 
+  componentDidMount = () => {
+    this.onSearchFormSubmit({ text: '' })
+  }
+
   onSearchFormSubmit = ({ text }) => {
     if (this.state.isLoading) {
       return


### PR DESCRIPTION
Right after opening POMS Lookup, an initial search will be performed (with an empty search term). This way, the user will see a list of recent items without having to search for anything.